### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress-ci.yml
+++ b/.github/workflows/cypress-ci.yml
@@ -1,4 +1,6 @@
 name: Cypress Tests with HTML Report
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mongoemon/cypressexample/security/code-scanning/1](https://github.com/mongoemon/cypressexample/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only needs to check out code and upload artifacts, it only requires read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
